### PR TITLE
chore: install k8s molecule pip dependency

### DIFF
--- a/context/requirements.txt
+++ b/context/requirements.txt
@@ -1,2 +1,3 @@
 ansible-dev-tools
+kubernetes==29.0.0
 molecule-plugins[podman]==23.5.3


### PR DESCRIPTION
It is not possibly to start Ansible workspace and run any command from the DevSpaces Ansible sample in AirGap environment, because it requires kubernetes dependency.

Can we include Kubernetes python client into the image?

Related issue: https://issues.redhat.com/browse/CRW-6562  